### PR TITLE
Including CTest before BUILD_TESTING

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@ There are a few CMake macros which can provide access to one of a few versions o
 ###### Example
 
 ```cmake
-
+include(CTest)
 if(BUILD_TESTING)
-  include(CTest)
   find_package(osrf_testing_tools_cpp REQUIRED)
   osrf_testing_tools_cpp_require_googletest(VERSION_GTE 1.8)  # ensures target gtest_main exists
 
@@ -174,8 +173,8 @@ You can use the above `osrf_testing_tools_cpp_add_test()` macro to set this envi
 For example, here is some CMake code that will build a test and add a CTest for it that properly sets the library pre-load environment variable on all support OS's:
 
 ```cmake
+include(CTest)
 if(BUILD_TESTING)
-  include(CTest)
   find_package(osrf_testing_tools_cpp REQUIRED)
   osrf_testing_tools_cpp_require_googletest(VERSION_GTE 1.8)  # ensures target gtest_main exists
 

--- a/osrf_testing_tools_cpp/CMakeLists.txt
+++ b/osrf_testing_tools_cpp/CMakeLists.txt
@@ -15,8 +15,8 @@ endif()
 
 add_subdirectory(src)
 
+include(CTest)
 if(BUILD_TESTING)
-  include(CTest)
   include(cmake/osrf_testing_tools_cpp_require_googletest.cmake)
   # ensures target gtest_main exists
   osrf_testing_tools_cpp_require_googletest(VERSION_GTE 1.8

--- a/test_osrf_testing_tools_cpp/CMakeLists.txt
+++ b/test_osrf_testing_tools_cpp/CMakeLists.txt
@@ -11,8 +11,8 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 endif()
 
+include(CTest)
 if(BUILD_TESTING)
-  include(CTest)
   find_package(osrf_testing_tools_cpp REQUIRED)
   osrf_testing_tools_cpp_require_googletest(VERSION_GTE 1.8)  # ensures target gtest_main exists
 


### PR DESCRIPTION
## Description
- BUILD_TESTING is defined when `include(CTest)`; therefore, it should be called before `if(BUILD_TESTING)`: https://cmake.org/cmake/help/v3.5/module/CTest.html.

## References
- Closes -#4