### PR TITLE
Allocate during initialization.

### DIFF
--- a/osrf_testing_tools_cpp/src/memory_tools/impl/apple.cpp
+++ b/osrf_testing_tools_cpp/src/memory_tools/impl/apple.cpp
@@ -76,10 +76,9 @@ OSX_INTERPOSE(apple_replacement_free, free);
 // End Interpose.
 
 // on shared library load, find and store the original memory function locations
-static void __apple_memory_tools_init(void) __attribute__((constructor));
-static void __apple_memory_tools_init(void)
+static __attribute__((constructor,used)) void __apple_memory_tools_init(void)
 {
-  get_static_initialization_complete() = true;
+  complete_static_initialization();
 }
 
 #endif  // defined(__APPLE__)

--- a/osrf_testing_tools_cpp/src/memory_tools/impl/linux.cpp
+++ b/osrf_testing_tools_cpp/src/memory_tools/impl/linux.cpp
@@ -39,7 +39,6 @@ find_original_function(const char * name)
       reinterpret_cast<void *>(original_function));
     exit(1);  // cannot throw, next best thing
   }
-  // fprintf(stderr, "original '%s()' is from '%s'\n", name, dl_info.dli_fname);
   return original_function;
 }
 
@@ -62,15 +61,14 @@ using FreeSignature = void (*)(void *);
 static FreeSignature g_original_free = nullptr;
 
 // on shared library load, find and store the original memory function locations
-static void __linux_memory_tools_init(void) __attribute__((constructor));
-static void __linux_memory_tools_init(void)
+static __attribute__((constructor)) void __linux_memory_tools_init(void)
 {
   g_original_malloc = find_original_function<MallocSignature>("malloc");
   g_original_realloc = find_original_function<ReallocSignature>("realloc");
   g_original_calloc = find_original_function<CallocSignature>("calloc");
   g_original_free = find_original_function<FreeSignature>("free");
 
-  get_static_initialization_complete() = true;
+  complete_static_initialization();
 }
 
 extern "C"

--- a/osrf_testing_tools_cpp/src/memory_tools/impl/unix_common.hpp
+++ b/osrf_testing_tools_cpp/src/memory_tools/impl/unix_common.hpp
@@ -17,6 +17,9 @@
 
 #include <cstddef>
 
+void
+complete_static_initialization();
+
 bool &
 get_static_initialization_complete();
 


### PR DESCRIPTION
We were seeing some errors during MacOS CI in release mode
using the memory_tools.  After doing some local debugging, I found
that it was segfaulting while trying to access a pthread variable
during initialization.  Looking at the code, it looks like it
is possible that the constructor in libmemory_interpose gets
called *before* the static constructor for the recursive_mutex
in unix_common.cpp, leading to this problem.  To work around
this, introduce a new function called complete_static_initialization()
which allocates the recursive_mutex and then sets
initialization_complete to true.  This should be safe from races between
construction and malloc/realloc/calloc on other threads, since those
won't be able to access the recursive_mutex until
initialization_complete is set to true.  It is not safe from races from
multiple copies of __apple_memory_tools_init/__linux_memory_tools_init,
but the rest of the code also assumes that and we don't think it is
possible.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

I believe this will fix the segfaults we are seeing in CI, like in https://ci.ros2.org/view/nightly/job/nightly_osx_release/890/ .  This is not yet ready for review or merging; I have only tested it on MacOS in release mode so far.  Opening for visibility.