### PR TITLE
Make sure there is an actual side-effect.

### DIFF
--- a/osrf_testing_tools_cpp/test/memory_tools/test_memory_tools.cpp
+++ b/osrf_testing_tools_cpp/test/memory_tools/test_memory_tools.cpp
@@ -149,7 +149,7 @@ TEST(TestMemoryTools, test_allocation_checking_tools) {
   EXPECT_EQ(4u, unexpected_frees);
 }
 
-char side_effect[1024];
+volatile char side_effect[1024];
 void my_first_function(const std::string& str)
 {
   void * some_memory = std::malloc(1024);
@@ -159,7 +159,7 @@ void my_first_function(const std::string& str)
   // is globally visible (assuring we have a side-effect).  This is enough to
   // keep the optimizer away.
   memcpy(some_memory, str.c_str(), str.length());
-  memcpy(side_effect, some_memory, str.length());
+  memcpy((void *)side_effect, some_memory, str.length());
   std::free(some_memory);
 }
 

--- a/osrf_testing_tools_cpp/test/memory_tools/test_memory_tools.cpp
+++ b/osrf_testing_tools_cpp/test/memory_tools/test_memory_tools.cpp
@@ -149,13 +149,17 @@ TEST(TestMemoryTools, test_allocation_checking_tools) {
   EXPECT_EQ(4u, unexpected_frees);
 }
 
+char side_effect[1024];
 void my_first_function(const std::string& str)
 {
   void * some_memory = std::malloc(1024);
   // We need to do something with the malloc'ed memory to make sure this
   // function doesn't get optimized away.  memset isn't enough, so we do a
-  // memcpy from a passed in string, which is enough to keep the optimizer away.
+  // memcpy from a passed in string, and then copy *that* out to an array that
+  // is globally visible (assuring we have a side-effect).  This is enough to
+  // keep the optimizer away.
   memcpy(some_memory, str.c_str(), str.length());
+  memcpy(side_effect, some_memory, str.length());
   std::free(some_memory);
 }
 

--- a/test_osrf_testing_tools_cpp/test/test_example_memory_tools.cpp
+++ b/test_osrf_testing_tools_cpp/test/test_example_memory_tools.cpp
@@ -21,7 +21,7 @@
 #include "osrf_testing_tools_cpp/memory_tools/memory_tools.hpp"
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
 
-char side_effect[1024];
+volatile char side_effect[1024];
 void my_first_function(const std::string& str)
 {
   void * some_memory = std::malloc(1024);
@@ -31,7 +31,7 @@ void my_first_function(const std::string& str)
   // is globally visible (assuring we have a side-effect).  This is enough to
   // keep the optimizer away.
   memcpy(some_memory, str.c_str(), str.length());
-  memcpy(side_effect, some_memory, str.length());
+  memcpy((void *)side_effect, some_memory, str.length());
   std::free(some_memory);
 }
 

--- a/test_osrf_testing_tools_cpp/test/test_example_memory_tools.cpp
+++ b/test_osrf_testing_tools_cpp/test/test_example_memory_tools.cpp
@@ -21,13 +21,17 @@
 #include "osrf_testing_tools_cpp/memory_tools/memory_tools.hpp"
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
 
+char side_effect[1024];
 void my_first_function(const std::string& str)
 {
   void * some_memory = std::malloc(1024);
   // We need to do something with the malloc'ed memory to make sure this
   // function doesn't get optimized away.  memset isn't enough, so we do a
-  // memcpy from a passed in string, which is enough to keep the optimizer away.
+  // memcpy from a passed in string, and then copy *that* out to an array that
+  // is globally visible (assuring we have a side-effect).  This is enough to
+  // keep the optimizer away.
   memcpy(some_memory, str.c_str(), str.length());
+  memcpy(side_effect, some_memory, str.length());
   std::free(some_memory);
 }
 


### PR DESCRIPTION
To truly keep away the optimizer, we make sure that my_first_function
has an externally-visible side-effect.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>