### PR TITLE
Dont use MPARK_CPP14_CONSTEXPR in Visual Studio 2017 19.15

### DIFF
--- a/osrf_testing_tools_cpp/include/osrf_testing_tools_cpp/vendor/mpark/variant/variant.hpp
+++ b/osrf_testing_tools_cpp/include/osrf_testing_tools_cpp/vendor/mpark/variant/variant.hpp
@@ -242,7 +242,8 @@ namespace std {
 #define MPARK_TYPE_PACK_ELEMENT
 #endif
 
-#if defined(__cpp_constexpr) && __cpp_constexpr >= 201304
+#if defined(__cpp_constexpr) && __cpp_constexpr >= 201304 && \
+           !(defined(_MSC_VER) && _MSC_VER <= 1915)
 #define MPARK_CPP14_CONSTEXPR
 #endif
 


### PR DESCRIPTION
I made a hotfix for avoiding the variant error under Visual Studio 2017 19.15