### PR TITLE
Add support for BFD when present

### DIFF
--- a/osrf_testing_tools_cpp/src/memory_tools/CMakeLists.txt
+++ b/osrf_testing_tools_cpp/src/memory_tools/CMakeLists.txt
@@ -10,14 +10,31 @@ add_library(memory_tools SHARED
   testing_helpers.cpp
   verbosity.cpp
 )
+
 target_include_directories(memory_tools
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
+
+find_library(DL_LIBRARY NAMES dl)
+find_library(BFD_LIBRARY NAMES bfd)
+
+if(DL_LIBRARY AND BFD_LIBRARY)
+  message(STATUS "Found bfd: ${BFD_LIBRARY}")
+endif()
+
 if(UNIX AND NOT APPLE)
   # On Linux like systems, add dl and use the normal library and LD_PRELOAD.
-  target_link_libraries(memory_tools dl)
+
+  if(DL_LIBRARY)
+    target_link_libraries(memory_tools ${DL_LIBRARY})
+  endif()
+
+  if(BFD_LIBRARY)
+    target_link_libraries(memory_tools ${BFD_LIBRARY})
+    target_compile_definitions(memory_tools PRIVATE BACKWARD_HAS_BFD=1)
+  endif()
 endif()
 target_compile_definitions(memory_tools
   PRIVATE "OSRF_TESTING_TOOLS_CPP_MEMORY_TOOLS_BUILDING_DLL")
@@ -26,6 +43,10 @@ add_library(memory_tools_interpose SHARED
   memory_tools.cpp
 )
 target_link_libraries(memory_tools_interpose memory_tools)
+
+if(BFD_LIBRARY)
+  target_compile_definitions(memory_tools_interpose PRIVATE BACKWARD_HAS_BFD=1)
+endif()
 
 # TODO(wjwwood): If on aarch64, so not set the preload environment variables, until fixed.
 # see: https://github.com/osrf/osrf_testing_tools_cpp/issues/3


### PR DESCRIPTION
Backward has support for BFD when it is present on the system.  It is available via the `binutils` package on Ubuntu.