### PR TITLE
Add -pthread unconditionally when compiling the gtest tests.

### DIFF
--- a/osrf_testing_tools_cpp/cmake/osrf_testing_tools_cpp_extract_and_build_googletest.cmake
+++ b/osrf_testing_tools_cpp/cmake/osrf_testing_tools_cpp_extract_and_build_googletest.cmake
@@ -64,9 +64,20 @@ macro(osrf_testing_tools_cpp_extract_and_build_googletest
   # settings on Windows
   set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
+  set(__prefix googletest-${GOOGLETEST_VERSION})
+  if(UNIX AND NOT APPLE)
+    # When building with asan (i.e. using colcon build --mixin asan-gcc),
+    # asan itself provides a "fake" pthread that tricks the pthread
+    # detection logic into thinking no link libraries are necessary
+    # (see https://wiki.gentoo.org/wiki/AddressSanitizer/Problems#pthread_linking_issues
+    # for some additional information).  To work around that, we unconditionally
+    # add the -pthread flag for Linux machines so it will always work
+    execute_process(COMMAND bash "-c" "sed -i 's@\${CMAKE_THREAD_LIBS_INIT}@\${CMAKE_THREAD_LIBS_INIT} -pthread@' ${__prefix}-src/googletest/cmake/internal_utils.cmake"
+      RESULT_VARIABLE result
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${__prefix}-extracted)
+  endif()
   # Add googletest directly to our build. This defines
   # the gtest and gtest_main targets.
-  set(__prefix googletest-${GOOGLETEST_VERSION})
   add_subdirectory(
     ${CMAKE_BINARY_DIR}/${__prefix}-extracted/${__prefix}-src
     ${CMAKE_BINARY_DIR}/${__prefix}-extracted/${__prefix}-build


### PR DESCRIPTION
This ensures that when we build with -fsanitize=address,
we can successfully link.

Along with ament/googletest#3, and a fix to Fast-RTPS, allows ros2 to be built with the colcon asan mixin (as discussed in https://github.com/colcon/colcon-mixin-repository/pull/12)