### PR TITLE
Add option to skip memory tool tests for address sanitizer

### DIFF
--- a/osrf_testing_tools_cpp/osrf_testing_tools_cppConfig.cmake.in
+++ b/osrf_testing_tools_cpp/osrf_testing_tools_cppConfig.cmake.in
@@ -40,6 +40,10 @@ endif()
 set_target_properties(osrf_testing_tools_cpp::memory_tools PROPERTIES
   LIBRARY_PRELOAD_ENVIRONMENT_VARIABLE ${memory_tools_extra_test_env})
 
+# Define option to skip tests which interfere with address sanitizer. This includes memory tool tests
+# which override LD_PRELOAD variable.
+option(SKIP_ASAN_INCOMPATIBLE_TESTS "Skip tests which are address sanitizer incompatible" OFF)
+
 # setup osrf_testing_tools_cpp_INCLUDE_DIRS so that header only things can be used without linking
 set(osrf_testing_tools_cpp_INCLUDE_DIRS "${__prefix_dir}/include")
 

--- a/osrf_testing_tools_cpp/src/memory_tools/CMakeLists.txt
+++ b/osrf_testing_tools_cpp/src/memory_tools/CMakeLists.txt
@@ -50,7 +50,8 @@ endif()
 
 # TODO(wjwwood): If on aarch64, so not set the preload environment variables, until fixed.
 # see: https://github.com/osrf/osrf_testing_tools_cpp/issues/3
-if(NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+# Memory tool tests are address sanitizer incompatible as they override LD_PRELOAD
+if(NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64" AND NOT SKIP_ASAN_INCOMPATIBLE_TESTS)
   if(APPLE)
     list(APPEND memory_tools_extra_test_env
       DYLD_INSERT_LIBRARIES=$<TARGET_FILE:memory_tools_interpose>)

--- a/osrf_testing_tools_cpp/test/memory_tools/CMakeLists.txt
+++ b/osrf_testing_tools_cpp/test/memory_tools/CMakeLists.txt
@@ -8,7 +8,8 @@ target_link_libraries(test_memory_tools
 # memory_tools doesn't work on Windows right now
 # TODO(wjwwood): disable on aarch64 for now, until fixed, see:
 #   https://github.com/osrf/osrf_testing_tools_cpp/issues/3
-if(NOT WIN32 AND NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+# Memory tool tests are address sanitizer incompatible as they override LD_PRELOAD
+if(NOT WIN32 AND NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64" AND NOT SKIP_ASAN_INCOMPATIBLE_TESTS)
   add_test(
     NAME "test_memory_tools"
     COMMAND

--- a/test_osrf_testing_tools_cpp/CMakeLists.txt
+++ b/test_osrf_testing_tools_cpp/CMakeLists.txt
@@ -11,6 +11,10 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 endif()
 
+# Define option to skip tests which interfere with address sanitizer. This includes memory tool tests
+# which override LD_PRELOAD variable.
+option(SKIP_ASAN_INCOMPATIBLE_TESTS "Skip tests which are address sanitizer incompatible" OFF)
+
 include(CTest)
 if(BUILD_TESTING)
   find_package(osrf_testing_tools_cpp REQUIRED)
@@ -19,7 +23,7 @@ if(BUILD_TESTING)
   # memory_tools doesn't work on Windows right now
   # TODO(wjwwood): disable on aarch64 for now, until fixed, see:
   #   https://github.com/osrf/osrf_testing_tools_cpp/issues/3
-  if(NOT WIN32 AND NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+  if(NOT WIN32 AND NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64" AND NOT SKIP_ASAN_INCOMPATIBLE_TESTS)
     add_executable(test_example_memory_tools_gtest test/test_example_memory_tools.cpp)
     target_link_libraries(test_example_memory_tools_gtest
       gtest_main


### PR DESCRIPTION
Introduce a new cmake option -DSKIP_ASAN_INCOMPATIBLE_TESTS to turn off
memory tool tests. This is needed to prevent the override of LD_PRELOAD or library path
to interfere from the working of address sanitizer

Connects to ros2/ci#245