### PR TITLE
Enable memory tools to work with address sanitizer

### DIFF
--- a/osrf_testing_tools_cpp/src/memory_tools/CMakeLists.txt
+++ b/osrf_testing_tools_cpp/src/memory_tools/CMakeLists.txt
@@ -52,10 +52,10 @@ endif()
 # see: https://github.com/osrf/osrf_testing_tools_cpp/issues/3
 if(NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
   # Option to add ASan lib path prefix to enable ASan to work as expected without interference from memory tools
-  option(OPTIONAL_ASAN_PRELOAD_ENV_VAR_OVERRIDE "Adds ASan lib path as a prefix to preload environment variable" OFF)
+  option(ASAN_PRELOAD_ENV_VAR_OVERRIDE "Adds ASan lib path as a prefix to preload environment variable" OFF)
   set(optional_preload_env_prefix "")
 
-  if(OPTIONAL_ASAN_PRELOAD_ENV_VAR_OVERRIDE)
+  if(ASAN_PRELOAD_ENV_VAR_OVERRIDE)
     execute_process(COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libasan.so
       OUTPUT_VARIABLE libasan_path OUTPUT_STRIP_TRAILING_WHITESPACE)
     if(libasan_path STREQUAL "libasan.so")

--- a/osrf_testing_tools_cpp/src/memory_tools/CMakeLists.txt
+++ b/osrf_testing_tools_cpp/src/memory_tools/CMakeLists.txt
@@ -48,6 +48,9 @@ if(BFD_LIBRARY)
   target_compile_definitions(memory_tools_interpose PRIVATE BACKWARD_HAS_BFD=1)
 endif()
 
+# Define option to add address sanitizer path to LD_PRELOAD before adding memory tools to the same
+option(OPTIONAL_ASAN_LD_PRELOAD_OVERRIDE "Adds asan lib as a prefix to LD_PRELOAD environment variable" OFF)
+
 # TODO(wjwwood): If on aarch64, so not set the preload environment variables, until fixed.
 # see: https://github.com/osrf/osrf_testing_tools_cpp/issues/3
 if(NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
@@ -55,8 +58,16 @@ if(NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
     list(APPEND memory_tools_extra_test_env
       DYLD_INSERT_LIBRARIES=$<TARGET_FILE:memory_tools_interpose>)
   elseif(UNIX)
-    list(APPEND memory_tools_extra_test_env
-      LD_PRELOAD=$<TARGET_FILE:memory_tools_interpose>)
+    set(memory_tools_path $<TARGET_FILE:memory_tools_interpose>)
+    if(OPTIONAL_ASAN_LD_PRELOAD_OVERRIDE)
+      execute_process(COMMAND bash "-c" "ldconfig -p | grep -e "libasan.*x86_64" | awk '{print $NF}'"
+      OUTPUT_VARIABLE libasan_path OUTPUT_STRIP_TRAILING_WHITESPACE)
+      list(APPEND memory_tools_extra_test_env
+        LD_PRELOAD=${libasan_path}:${memory_tools_path})
+    else()
+      list(APPEND memory_tools_extra_test_env
+        LD_PRELOAD=${memory_tools_path})
+    endif()
   endif()
 endif()
 

--- a/osrf_testing_tools_cpp/src/memory_tools/CMakeLists.txt
+++ b/osrf_testing_tools_cpp/src/memory_tools/CMakeLists.txt
@@ -48,26 +48,30 @@ if(BFD_LIBRARY)
   target_compile_definitions(memory_tools_interpose PRIVATE BACKWARD_HAS_BFD=1)
 endif()
 
-# Define option to add address sanitizer path to LD_PRELOAD before adding memory tools to the same
-option(OPTIONAL_ASAN_LD_PRELOAD_OVERRIDE "Adds asan lib as a prefix to LD_PRELOAD environment variable" OFF)
-
 # TODO(wjwwood): If on aarch64, so not set the preload environment variables, until fixed.
 # see: https://github.com/osrf/osrf_testing_tools_cpp/issues/3
 if(NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+  # Option to add ASan lib path prefix to enable ASan to work as expected without interference from memory tools
+  option(OPTIONAL_ASAN_PRELOAD_ENV_VAR_OVERRIDE "Adds ASan lib path as a prefix to preload environment variable" OFF)
+  set(optional_preload_env_prefix "")
+
+  if(OPTIONAL_ASAN_PRELOAD_ENV_VAR_OVERRIDE)
+    execute_process(COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libasan.so
+      OUTPUT_VARIABLE libasan_path OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(libasan_path STREQUAL "libasan.so")
+      message(WARNING "Path for libasan.so not found. Address sanitizer may not work correctly")
+      set(optional_preload_env_prefix "")
+    else()
+      set(optional_preload_env_prefix "${libasan_path}:")
+    endif()
+  endif()
+
   if(APPLE)
     list(APPEND memory_tools_extra_test_env
-      DYLD_INSERT_LIBRARIES=$<TARGET_FILE:memory_tools_interpose>)
+      DYLD_INSERT_LIBRARIES=${optional_preload_env_prefix}$<TARGET_FILE:memory_tools_interpose>)
   elseif(UNIX)
-    set(memory_tools_path $<TARGET_FILE:memory_tools_interpose>)
-    if(OPTIONAL_ASAN_LD_PRELOAD_OVERRIDE)
-      execute_process(COMMAND bash "-c" "ldconfig -p | grep -e "libasan.*x86_64" | awk '{print $NF}'"
-      OUTPUT_VARIABLE libasan_path OUTPUT_STRIP_TRAILING_WHITESPACE)
-      list(APPEND memory_tools_extra_test_env
-        LD_PRELOAD=${libasan_path}:${memory_tools_path})
-    else()
-      list(APPEND memory_tools_extra_test_env
-        LD_PRELOAD=${memory_tools_path})
-    endif()
+    list(APPEND memory_tools_extra_test_env
+      LD_PRELOAD=${optional_preload_env_prefix}$<TARGET_FILE:memory_tools_interpose>)
   endif()
 endif()
 


### PR DESCRIPTION
Add libasan path as a prefix to LD_PRELOAD before appending memory
tools lib path to it. This is required to enable address sanitizer to work
properly as it needs libasan to be first in the initial library load list.

Signed-off-by: Sachin Suresh Bhat <bhatsach@amazon.com>

Connects to ros2/ci#245