### PR TITLE
Link against dl if DL_LIBRARY not found

### DIFF
--- a/osrf_testing_tools_cpp/src/memory_tools/CMakeLists.txt
+++ b/osrf_testing_tools_cpp/src/memory_tools/CMakeLists.txt
@@ -29,6 +29,8 @@ if(UNIX AND NOT APPLE)
 
   if(DL_LIBRARY)
     target_link_libraries(memory_tools ${DL_LIBRARY})
+  else()
+    target_link_libraries(memory_tools dl)
   endif()
 
   if(BFD_LIBRARY)


### PR DESCRIPTION
The commit adding support for BFD (0d5e976), broke our aarch64 cross-compile build since `dl` cannot be found anymore. This fix allows osrf_testing_tools_cpp to fall back on the old linking strategy.