### PR TITLE
Static Allocator - Aligned allocations

### DIFF
--- a/osrf_testing_tools_cpp/src/CMakeLists.txt
+++ b/osrf_testing_tools_cpp/src/CMakeLists.txt
@@ -3,3 +3,5 @@ add_subdirectory(test_runner)
 
 set(memory_tools_extra_test_env "${memory_tools_extra_test_env}" PARENT_SCOPE)
 set(memory_tools_is_available "${memory_tools_is_available}" PARENT_SCOPE)
+set(memory_tools_src_dir_internal_testing_only
+  "${memory_tools_src_dir_internal_testing_only}" PARENT_SCOPE)

--- a/osrf_testing_tools_cpp/src/memory_tools/CMakeLists.txt
+++ b/osrf_testing_tools_cpp/src/memory_tools/CMakeLists.txt
@@ -96,3 +96,5 @@ install(EXPORT memory_tools_interpose
 
 set(memory_tools_extra_test_env "${memory_tools_extra_test_env}" PARENT_SCOPE)
 set(memory_tools_is_available "${memory_tools_is_available}" PARENT_SCOPE)
+set(memory_tools_src_dir_internal_testing_only
+  "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src>" PARENT_SCOPE)

--- a/osrf_testing_tools_cpp/src/memory_tools/impl/linux.cpp
+++ b/osrf_testing_tools_cpp/src/memory_tools/impl/linux.cpp
@@ -42,13 +42,21 @@ find_original_function(const char * name)
   return original_function;
 }
 
-using osrf_testing_tools_cpp::memory_tools::impl::StaticAllocator;
-// the size was found experimentally on Ubuntu Linux 16.04 x86_64
-using StaticAllocatorT = StaticAllocator<8388608>;
-// used to fullfil calloc call from dlerror.c during initialization of original functions
-// constructor is called on first use with a placement-new and the static storage
+// An amount of memory that is greater than what is needed for static initialization
+// for any test we run. It was found experimentally on Ubuntu Linux 16.04 x86_64.
+static const size_t STATIC_ALLOCATOR_SIZE = 0x800000;
+using StaticAllocatorT =
+  osrf_testing_tools_cpp::memory_tools::impl::StaticAllocator<STATIC_ALLOCATOR_SIZE>;
 static uint8_t g_static_allocator_storage[sizeof(StaticAllocatorT)];
-static StaticAllocatorT * g_static_allocator = nullptr;
+
+// Contains global allocator to make 100% sure to avoid Static Initialization Order Fiasco.
+// "Construct on first use" idiom
+StaticAllocatorT * g_static_allocator() {
+  // placement-new the static allocator in preallocated storage
+  // which is used while finding the original memory functions
+  static StaticAllocatorT * alloc = new (g_static_allocator_storage) StaticAllocatorT;
+  return alloc;
+}
 
 // storage for original malloc/realloc/calloc/free
 using MallocSignature = void * (*)(size_t);
@@ -78,12 +86,7 @@ void *
 malloc(size_t size) noexcept
 {
   if (!get_static_initialization_complete()) {
-    if (nullptr == g_static_allocator) {
-      // placement-new the static allocator
-      // which is used while finding the original memory functions
-      g_static_allocator = new (g_static_allocator_storage) StaticAllocatorT;
-    }
-    return g_static_allocator->allocate(size);
+     return g_static_allocator()->allocate(size);
   }
   return unix_replacement_malloc(size, g_original_malloc);
 }
@@ -92,12 +95,7 @@ void *
 realloc(void * pointer, size_t size) noexcept
 {
   if (!get_static_initialization_complete()) {
-    if (nullptr == g_static_allocator) {
-      // placement-new the static allocator
-      // which is used while finding the original memory functions
-      g_static_allocator = new (g_static_allocator_storage) StaticAllocatorT;
-    }
-    return g_static_allocator->reallocate(pointer, size);
+    return g_static_allocator()->reallocate(pointer, size);
   }
   return unix_replacement_realloc(pointer, size, g_original_realloc);
 }
@@ -106,12 +104,7 @@ void *
 calloc(size_t count, size_t size) noexcept
 {
   if (!get_static_initialization_complete()) {
-    if (nullptr == g_static_allocator) {
-      // placement-new the static allocator
-      // which is used while finding the original memory functions
-      g_static_allocator = new (g_static_allocator_storage) StaticAllocatorT;
-    }
-    return g_static_allocator->zero_allocate(count, size);
+    return g_static_allocator()->zero_allocate(count, size);
   }
   return unix_replacement_calloc(count, size, g_original_calloc);
 }
@@ -119,7 +112,7 @@ calloc(size_t count, size_t size) noexcept
 void
 free(void * pointer) noexcept
 {
-  if (nullptr == pointer || g_static_allocator->deallocate(pointer)) {
+  if (nullptr == pointer || g_static_allocator()->deallocate(pointer)) {
     // free of nullptr or,
     // memory was originally allocated by static allocator, no need to pass to "real" free
     return;

--- a/osrf_testing_tools_cpp/src/memory_tools/impl/linux.cpp
+++ b/osrf_testing_tools_cpp/src/memory_tools/impl/linux.cpp
@@ -51,7 +51,9 @@ static uint8_t g_static_allocator_storage[sizeof(StaticAllocatorT)];
 
 // Contains global allocator to make 100% sure to avoid Static Initialization Order Fiasco.
 // "Construct on first use" idiom
-StaticAllocatorT * get_static_allocator() {
+static StaticAllocatorT *
+get_static_allocator()
+{
   // placement-new the static allocator in preallocated storage
   // which is used while finding the original memory functions
   static StaticAllocatorT * alloc = new (g_static_allocator_storage) StaticAllocatorT;

--- a/osrf_testing_tools_cpp/src/memory_tools/impl/linux.cpp
+++ b/osrf_testing_tools_cpp/src/memory_tools/impl/linux.cpp
@@ -45,8 +45,8 @@ find_original_function(const char * name)
 // An amount of memory that is greater than what is needed for static initialization
 // for any test we run. It was found experimentally on Ubuntu Linux 16.04 x86_64.
 static const size_t STATIC_ALLOCATOR_SIZE = 0x800000;
-using StaticAllocatorT =
-  osrf_testing_tools_cpp::memory_tools::impl::StaticAllocator<STATIC_ALLOCATOR_SIZE>;
+using osrf_testing_tools_cpp::memory_tools::impl::StaticAllocator;
+using StaticAllocatorT = StaticAllocator<STATIC_ALLOCATOR_SIZE>;
 static uint8_t g_static_allocator_storage[sizeof(StaticAllocatorT)];
 
 // Contains global allocator to make 100% sure to avoid Static Initialization Order Fiasco.
@@ -86,7 +86,7 @@ void *
 malloc(size_t size) noexcept
 {
   if (!get_static_initialization_complete()) {
-     return g_static_allocator()->allocate(size);
+    return g_static_allocator()->allocate(size);
   }
   return unix_replacement_malloc(size, g_original_malloc);
 }

--- a/osrf_testing_tools_cpp/src/memory_tools/impl/linux.cpp
+++ b/osrf_testing_tools_cpp/src/memory_tools/impl/linux.cpp
@@ -44,14 +44,14 @@ find_original_function(const char * name)
 
 // An amount of memory that is greater than what is needed for static initialization
 // for any test we run. It was found experimentally on Ubuntu Linux 16.04 x86_64.
-static const size_t STATIC_ALLOCATOR_SIZE = 0x800000;
+static constexpr size_t STATIC_ALLOCATOR_SIZE = 0x800000;
 using osrf_testing_tools_cpp::memory_tools::impl::StaticAllocator;
 using StaticAllocatorT = StaticAllocator<STATIC_ALLOCATOR_SIZE>;
 static uint8_t g_static_allocator_storage[sizeof(StaticAllocatorT)];
 
 // Contains global allocator to make 100% sure to avoid Static Initialization Order Fiasco.
 // "Construct on first use" idiom
-StaticAllocatorT * g_static_allocator() {
+StaticAllocatorT * get_static_allocator() {
   // placement-new the static allocator in preallocated storage
   // which is used while finding the original memory functions
   static StaticAllocatorT * alloc = new (g_static_allocator_storage) StaticAllocatorT;
@@ -86,7 +86,7 @@ void *
 malloc(size_t size) noexcept
 {
   if (!get_static_initialization_complete()) {
-    return g_static_allocator()->allocate(size);
+    return get_static_allocator()->allocate(size);
   }
   return unix_replacement_malloc(size, g_original_malloc);
 }
@@ -95,7 +95,7 @@ void *
 realloc(void * pointer, size_t size) noexcept
 {
   if (!get_static_initialization_complete()) {
-    return g_static_allocator()->reallocate(pointer, size);
+    return get_static_allocator()->reallocate(pointer, size);
   }
   return unix_replacement_realloc(pointer, size, g_original_realloc);
 }
@@ -104,7 +104,7 @@ void *
 calloc(size_t count, size_t size) noexcept
 {
   if (!get_static_initialization_complete()) {
-    return g_static_allocator()->zero_allocate(count, size);
+    return get_static_allocator()->zero_allocate(count, size);
   }
   return unix_replacement_calloc(count, size, g_original_calloc);
 }
@@ -112,7 +112,7 @@ calloc(size_t count, size_t size) noexcept
 void
 free(void * pointer) noexcept
 {
-  if (nullptr == pointer || g_static_allocator()->deallocate(pointer)) {
+  if (nullptr == pointer || get_static_allocator()->deallocate(pointer)) {
     // free of nullptr or,
     // memory was originally allocated by static allocator, no need to pass to "real" free
     return;

--- a/osrf_testing_tools_cpp/src/memory_tools/impl/static_allocator.hpp
+++ b/osrf_testing_tools_cpp/src/memory_tools/impl/static_allocator.hpp
@@ -32,15 +32,15 @@ namespace impl
 // Alignment of the largest primitive type for this system.
 static constexpr size_t MAX_ALIGN = alignof(std::max_align_t);
 
-/// Bump n up to a multiple of alignment.
+/// Round value up to a multiple of alignment.
 /**
-  * Bit twiddling trick cribbed from Boost.
+  * Implementation cribbed from Boost.
   * https://github.com/boostorg/align/blob/develop/include/boost/align/align_up.hpp
   */
-inline size_t
-align_up(size_t n, size_t alignment) noexcept
+static constexpr inline std::size_t
+align_up(std::size_t value, std::size_t alignment) noexcept
 {
-  return (n+(alignment-1)) & ~(alignment-1);
+  return (value + alignment - 1) & ~(alignment - 1);
 }
 
 template<size_t MemoryPoolSize>

--- a/osrf_testing_tools_cpp/src/memory_tools/impl/static_allocator.hpp
+++ b/osrf_testing_tools_cpp/src/memory_tools/impl/static_allocator.hpp
@@ -45,9 +45,10 @@ public:
   void *
   allocate(size_t size)
   {
-    if (size <= size_t(std::distance(stack_pointer_, end_))) {
+    auto const aligned_size = align_up(size);
+    if (aligned_size <= static_cast<decltype(aligned_size)>(std::distance(end_, stack_pointer_))) {
       uint8_t * result = stack_pointer_;
-      stack_pointer_ += size;
+      stack_pointer_ += aligned_size;
       return result;
     }
     SAFE_FWRITE(stderr, "StackAllocator.allocate() -> nullptr\n");
@@ -105,7 +106,14 @@ public:
   }
 
 private:
-  uint8_t memory_pool_[MemoryPoolSize];
+  static std::size_t
+  align_up(std::size_t n) noexcept
+  {
+    return (n+(alignment-1)) & ~(alignment-1);
+  }
+
+  static auto constexpr alignment = alignof(std::max_align_t);
+  alignas(alignment) uint8_t memory_pool_[MemoryPoolSize];
   uint8_t * begin_;
   uint8_t * end_;
   uint8_t * stack_pointer_;
@@ -114,13 +122,5 @@ private:
 }  // namespace impl
 }  // namespace memory_tools
 }  // namespace osrf_testing_tools_cpp
-
-int main(void)
-{
-  osrf_testing_tools_cpp::memory_tools::impl::StaticAllocator<64> sa;
-  void * mem = sa.allocate(16);
-  (void)mem;
-  return 0;
-}
 
 #endif  // MEMORY_TOOLS__IMPL__STATIC_ALLOCATOR_HPP_

--- a/osrf_testing_tools_cpp/test/memory_tools/CMakeLists.txt
+++ b/osrf_testing_tools_cpp/test/memory_tools/CMakeLists.txt
@@ -4,6 +4,8 @@ target_link_libraries(test_memory_tools
   memory_tools
   gtest_main
 )
+target_include_directories(test_memory_tools
+  PRIVATE ${memory_tools_src_dir_internal_testing_only})
 
 if(memory_tools_is_available)
   add_test(


### PR DESCRIPTION
* Remove unwanted `main` symbol
* Centralize copy-pasted code for getting static allocator
* Align the memory pool and returned memory from in the static allocator to std::max_align_t in order to make it all safe for optimized builds

Fixes osrf/osrf_testing_tools_cpp#30
Unblocks ros2/rmw_fastrtps#272

Signed-off-by: Emerson Knapp <eknapp@amazon.com>