### PR TITLE
Compatibility with binutils 2.34

### DIFF
--- a/osrf_testing_tools_cpp/src/memory_tools/vendor/bombela/backward-cpp/backward.hpp
+++ b/osrf_testing_tools_cpp/src/memory_tools/vendor/bombela/backward-cpp/backward.hpp
@@ -65,6 +65,17 @@
 # endif
 #endif
 
+// binutils 2.34 compatibility
+#ifndef bfd_get_section_flags
+#define bfd_get_section_flags(H, S) bfd_section_flags(S)
+#endif
+#ifndef bfd_get_section_size
+#define bfd_get_section_size(S) bfd_section_size(S)
+#endif
+#ifndef bfd_get_section_vma
+#define bfd_get_section_vma(H, S) bfd_section_vma(S)
+#endif
+
 #include <algorithm>
 #include <cctype>
 #include <cstdio>


### PR DESCRIPTION
Binutils 2.34 dropped a parameter from some macros. Check to see if
macro is defined, if not define the appropriate macro interface. Change
is noted here:
https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=commitdiff;h=fd3619828e94a24a92cddec42cbc0ab33352eeb4