### PR TITLE
fix execinfo.h not found for QNX

### DIFF
--- a/osrf_testing_tools_cpp/src/memory_tools/count_function_occurrences_in_backtrace.hpp
+++ b/osrf_testing_tools_cpp/src/memory_tools/count_function_occurrences_in_backtrace.hpp
@@ -17,7 +17,7 @@
 
 #include "./safe_fwrite.hpp"
 
-#if defined(_WIN32)
+#if defined(_WIN32) || defined(__QNXNTO__)
 
 // Include nothing for now.
 
@@ -50,7 +50,7 @@ struct is_function_pointer
   >
 {};
 
-#if defined(_WIN32)
+#if defined(_WIN32) || defined(__QNXNTO__)
 
 struct count_function_occurrences_in_backtrace_is_implemented : std::false_type {};
 


### PR DESCRIPTION
Fixes #50 

Description:
Resolves the issue of execinfo.h not found as backtrace() function is not implemented for QNX

Target OS version: 
QNX 7.1