### PR TITLE
Workarounds for Android

### DIFF
--- a/osrf_testing_tools_cpp/src/memory_tools/count_function_occurrences_in_backtrace.hpp
+++ b/osrf_testing_tools_cpp/src/memory_tools/count_function_occurrences_in_backtrace.hpp
@@ -17,11 +17,11 @@
 
 #include "./safe_fwrite.hpp"
 
-#if defined(_WIN32)
+#if defined(_WIN32) || defined(__ANDROID__)
 
 // Include nothing for now.
 
-#else  // defined(_WIN32)
+#else  // defined(_WIN32) || defined(__ANDROID__)
 
 #include <cstdio>
 #include <cstdlib>
@@ -30,7 +30,7 @@
 #include <execinfo.h>
 #include <stdexcept>
 
-#endif  // defined(_WIN32)
+#endif  // defined(_WIN32) || defined(__ANDROID__)
 
 namespace osrf_testing_tools_cpp
 {
@@ -50,7 +50,7 @@ struct is_function_pointer
   >
 {};
 
-#if defined(_WIN32)
+#if defined(_WIN32) || defined(__ANDROID__)
 
 struct count_function_occurrences_in_backtrace_is_implemented : std::false_type {};
 
@@ -58,10 +58,11 @@ template<int MaxBacktraceSize>
 size_t
 impl_count_function_occurrences_in_backtrace(void * function_address)
 {
+  (void) function_address;
   throw not_implemented();
 }
 
-#else  // defined(_WIN32)
+#else  // defined(_WIN32) || defined(__ANDROID__)
 
 struct count_function_occurrences_in_backtrace_is_implemented : std::true_type {};
 

--- a/osrf_testing_tools_cpp/src/memory_tools/memory_tools.cpp
+++ b/osrf_testing_tools_cpp/src/memory_tools/memory_tools.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if defined(__linux__)
+#if defined(__linux__) && !defined(__ANDROID__)
 
 #include "./impl/linux.cpp"
 #include "./impl/unix_common.cpp"

--- a/osrf_testing_tools_cpp/src/memory_tools/memory_tools_service.cpp
+++ b/osrf_testing_tools_cpp/src/memory_tools/memory_tools_service.cpp
@@ -96,7 +96,7 @@ MemoryToolsService::print_backtrace()
 StackTrace *
 MemoryToolsService::get_stack_trace()
 {
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__ANDROID__)
   if (nullptr == impl_->lazy_stack_trace) {
     backward::StackTrace st;
     st.load_here(256);
@@ -107,7 +107,7 @@ MemoryToolsService::get_stack_trace()
   return impl_->lazy_stack_trace.get();
 #else
   return nullptr;
-#endif
+#endif  // !defined(_WIN32) && !defined(__ANDROID__)
 }
 
 const char *

--- a/osrf_testing_tools_cpp/src/memory_tools/print_backtrace.hpp
+++ b/osrf_testing_tools_cpp/src/memory_tools/print_backtrace.hpp
@@ -15,7 +15,7 @@
 #ifndef MEMORY_TOOLS__PRINT_BACKTRACE_HPP_
 #define MEMORY_TOOLS__PRINT_BACKTRACE_HPP_
 
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__ANDROID__)
 
 # pragma GCC diagnostic push
 # ifdef __clang__
@@ -27,7 +27,7 @@
 
 # pragma GCC diagnostic pop
 
-#endif  // _WIN32
+#endif  // !defined(_WIN32) && !defined(__ANDROID__)
 
 namespace osrf_testing_tools_cpp
 {
@@ -38,14 +38,14 @@ template<int MaxStackDepth = 64>
 void
 print_backtrace(FILE * out = stderr)
 {
-#if !defined(_WIN32)
+#if !defined(_WIN32) && !defined(__ANDROID__)
   backward::StackTrace st;
   st.load_here(MaxStackDepth);
   backward::Printer p;
   p.print(st, out);
 #else
-  fprintf(out, "backtrace unavailable on Windows\n");
-#endif
+  fprintf(out, "backtrace unavailable on Windows and Android\n");
+#endif  // !defined(_WIN32) && !defined(__ANDROID__)
 }
 
 }  // namespace memory_tools

--- a/osrf_testing_tools_cpp/src/memory_tools/stack_trace.cpp
+++ b/osrf_testing_tools_cpp/src/memory_tools/stack_trace.cpp
@@ -31,40 +31,40 @@ SourceLocation::~SourceLocation()
 const std::string &
 SourceLocation::function() const
 {
-#if !defined(_WIN32)
+#if !defined(_WIN32) && !defined(__ANDROID__)
   return impl_->source_location->function;
 #else
-  throw std::runtime_error("not implemented on Windows");
+  throw std::runtime_error("not implemented on Windows or Android");
 #endif
 }
 
 const std::string &
 SourceLocation::filename() const
 {
-#if !defined(_WIN32)
+#if !defined(_WIN32) && !defined(__ANDROID__)
   return impl_->source_location->filename;
 #else
-  throw std::runtime_error("not implemented on Windows");
+  throw std::runtime_error("not implemented on Windows or Android");
 #endif
 }
 
 size_t
 SourceLocation::line() const
 {
-#if !defined(_WIN32)
+#if !defined(_WIN32) && !defined(__ANDROID__)
   return impl_->source_location->line;
 #else
-  throw std::runtime_error("not implemented on Windows");
+  throw std::runtime_error("not implemented on Windows or Android");
 #endif
 }
 
 size_t
 SourceLocation::column() const
 {
-#if !defined(_WIN32)
+#if !defined(_WIN32) && !defined(__ANDROID__)
   return impl_->source_location->col;
 #else
-  throw std::runtime_error("not implemented on Windows");
+  throw std::runtime_error("not implemented on Windows or Android");
 #endif
 }
 
@@ -82,60 +82,60 @@ Trace::~Trace()
 void *
 Trace::address() const
 {
-#if !defined(_WIN32)
+#if !defined(_WIN32) && !defined(__ANDROID__)
   return impl_->resolved_trace.addr;
 #else
-  throw std::runtime_error("not implemented on Windows");
+  throw std::runtime_error("not implemented on Windows or Android");
 #endif
 }
 
 size_t
 Trace::index_in_stack() const
 {
-#if !defined(_WIN32)
+#if !defined(_WIN32) && !defined(__ANDROID__)
   return impl_->resolved_trace.idx;
 #else
-  throw std::runtime_error("not implemented on Windows");
+  throw std::runtime_error("not implemented on Windows or Android");
 #endif
 }
 
 const std::string &
 Trace::object_filename() const
 {
-#if !defined(_WIN32)
+#if !defined(_WIN32) && !defined(__ANDROID__)
   return impl_->resolved_trace.object_filename;
 #else
-  throw std::runtime_error("not implemented on Windows");
+  throw std::runtime_error("not implemented on Windows or Android");
 #endif
 }
 
 const std::string &
 Trace::object_function() const
 {
-#if !defined(_WIN32)
+#if !defined(_WIN32) && !defined(__ANDROID__)
   return impl_->resolved_trace.object_function;
 #else
-  throw std::runtime_error("not implemented on Windows");
+  throw std::runtime_error("not implemented on Windows or Android");
 #endif
 }
 
 const SourceLocation &
 Trace::source_location() const
 {
-#if !defined(_WIN32)
+#if !defined(_WIN32) && !defined(__ANDROID__)
   return impl_->source_location;
 #else
-  throw std::runtime_error("not implemented on Windows");
+  throw std::runtime_error("not implemented on Windows or Android");
 #endif
 }
 
 const std::vector<SourceLocation> &
 Trace::inlined_source_locations() const
 {
-#if !defined(_WIN32)
+#if !defined(_WIN32) && !defined(__ANDROID__)
   return impl_->inlined_source_locations;
 #else
-  throw std::runtime_error("not implemented on Windows");
+  throw std::runtime_error("not implemented on Windows or Android");
 #endif
 }
 
@@ -149,27 +149,27 @@ StackTrace::~StackTrace()
 std::thread::id
 StackTrace::thread_id() const
 {
-#if !defined(_WIN32)
+#if !defined(_WIN32) && !defined(__ANDROID__)
   return impl_->thread_id;
 #else
-  throw std::runtime_error("not implemented on Windows");
+  throw std::runtime_error("not implemented on Windows or Android");
 #endif
 }
 
 const std::vector<Trace> &
 StackTrace::get_traces() const
 {
-#if !defined(_WIN32)
+#if !defined(_WIN32) && !defined(__ANDROID__)
   return impl_->traces;
 #else
-  throw std::runtime_error("not implemented on Windows");
+  throw std::runtime_error("not implemented on Windows or Android");
 #endif
 }
 
 std::vector<Trace>
 StackTrace::get_traces_from_function_name(const char * function_name) const
 {
-#if !defined(_WIN32)
+#if !defined(_WIN32) && !defined(__ANDROID__)
   std::vector<Trace> result;
   bool function_found = false;
   for (const Trace & trace : impl_->traces) {
@@ -182,7 +182,8 @@ StackTrace::get_traces_from_function_name(const char * function_name) const
   }
   return result;
 #else
-  throw std::runtime_error("not implemented on Windows");
+  (void) function_name;
+  throw std::runtime_error("not implemented on Windows or Android");
 #endif
 }
 

--- a/osrf_testing_tools_cpp/src/memory_tools/stack_trace_impl.hpp
+++ b/osrf_testing_tools_cpp/src/memory_tools/stack_trace_impl.hpp
@@ -21,7 +21,7 @@
 
 #include "osrf_testing_tools_cpp/memory_tools/stack_trace.hpp"
 
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__ANDROID__)
 
 #pragma GCC diagnostic push
 #ifdef __clang__
@@ -123,6 +123,6 @@ struct StackTraceImpl {};
 }  // namespace memory_tools
 }  // namespace osrf_testing_tools_cpp
 
-#endif  // _WIN32
+#endif  // !defined(_WIN32) && !defined(__ANDROID__)
 
 #endif  // OSRF_TESTING_TOOLS_CPP__STACK_TRACE_IMPL_HPP_


### PR DESCRIPTION
Android does not have support for `execinfo.h`, this just avoid compiling code paths that use that.