### PR TITLE
[osrf_testing_tools_cpp] Add warnings

### DIFF
--- a/osrf_testing_tools_cpp/CMakeLists.txt
+++ b/osrf_testing_tools_cpp/CMakeLists.txt
@@ -10,7 +10,9 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+  add_compile_options(-Wall -Wextra -Wpedantic
+  -Wformat=2 -Wconversion -Woverloaded-virtual
+  -Wshadow -Wnon-virtual-dtor)
 endif()
 
 add_subdirectory(src)

--- a/osrf_testing_tools_cpp/src/memory_tools/stack_trace_impl.hpp
+++ b/osrf_testing_tools_cpp/src/memory_tools/stack_trace_impl.hpp
@@ -39,8 +39,8 @@ namespace memory_tools
 struct SourceLocationImpl
 {
   SourceLocationImpl() = delete;
-  explicit SourceLocationImpl(const backward::ResolvedTrace::SourceLoc * source_location)
-  : source_location(source_location)
+  explicit SourceLocationImpl(const backward::ResolvedTrace::SourceLoc * sl)
+  : source_location(sl)
   {}
 
   virtual ~SourceLocationImpl() {}
@@ -83,8 +83,8 @@ struct TraceImpl
 struct StackTraceImpl
 {
   StackTraceImpl() = delete;
-  explicit StackTraceImpl(backward::StackTrace stack_trace, std::thread::id thread_id)
-  : stack_trace(stack_trace), thread_id(thread_id)
+  explicit StackTraceImpl(backward::StackTrace st, std::thread::id tid)
+  : stack_trace(st), thread_id(tid)
   {
     trace_resolver.load_stacktrace(stack_trace);
     traces.reserve(stack_trace.size());

--- a/osrf_testing_tools_cpp/src/memory_tools/vendor/bombela/backward-cpp/backward.hpp
+++ b/osrf_testing_tools_cpp/src/memory_tools/vendor/bombela/backward-cpp/backward.hpp
@@ -3199,7 +3199,7 @@ public:
     if (st.size() == 0) {
       return;
     }
-    _symbols.reset(backtrace_symbols(st.begin(), st.size()));
+    _symbols.reset(backtrace_symbols(st.begin(), static_cast<int>(st.size())));
   }
 
   ResolvedTrace resolve(ResolvedTrace trace) {

--- a/osrf_testing_tools_cpp/src/test_runner/main.cpp
+++ b/osrf_testing_tools_cpp/src/test_runner/main.cpp
@@ -39,7 +39,7 @@ int
 main(int argc, char const * argv[])
 {
   std::vector<std::string> args;
-  args.reserve(static_cast<unsigned long>(argc));
+  args.reserve(static_cast<size_t>(argc));
   for (int i = 0; i < argc; ++i) {
     if (i == 0) {
       continue;

--- a/osrf_testing_tools_cpp/src/test_runner/main.cpp
+++ b/osrf_testing_tools_cpp/src/test_runner/main.cpp
@@ -39,7 +39,7 @@ int
 main(int argc, char const * argv[])
 {
   std::vector<std::string> args;
-  args.reserve(argc);
+  args.reserve(static_cast<unsigned long>(argc));
   for (int i = 0; i < argc; ++i) {
     if (i == 0) {
       continue;

--- a/osrf_testing_tools_cpp/test/memory_tools/test_memory_tools.cpp
+++ b/osrf_testing_tools_cpp/test/memory_tools/test_memory_tools.cpp
@@ -200,9 +200,9 @@ TEST(TestMemoryTools, test_example) {
   }, "unexpected malloc");
   // There are also explicit begin/end functions if you need variables to leave the scope
   osrf_testing_tools_cpp::memory_tools::expect_no_malloc_begin();
-  int result = my_second_function(1, 2);
+  int output = my_second_function(1, 2);
   osrf_testing_tools_cpp::memory_tools::expect_no_malloc_end();
-  EXPECT_EQ(result, 3);
+  EXPECT_EQ(output, 3);
 
   // enable monitoring only works in the current thread, but you can enable it for all threads
   osrf_testing_tools_cpp::memory_tools::enable_monitoring_in_all_threads();

--- a/osrf_testing_tools_cpp/test/test_runner/assert_env_vars.cpp
+++ b/osrf_testing_tools_cpp/test/test_runner/assert_env_vars.cpp
@@ -91,7 +91,7 @@ int main(int argc, char * argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
 
-  g_args.reserve(argc);
+  g_args.reserve(static_cast<unsigned long>(argc));
   for (int i = 0; i < argc; ++i) {
     if (i == 0) {
       continue;

--- a/osrf_testing_tools_cpp/test/test_runner/assert_env_vars.cpp
+++ b/osrf_testing_tools_cpp/test/test_runner/assert_env_vars.cpp
@@ -91,7 +91,7 @@ int main(int argc, char * argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
 
-  g_args.reserve(static_cast<unsigned long>(argc));
+  g_args.reserve(static_cast<size_t>(argc));
   for (int i = 0; i < argc; ++i) {
     if (i == 0) {
       continue;


### PR DESCRIPTION
This PR enables `Wformat=2`, `Wconversion`, `Woverloaded-virtual`, `Wshadow`, and `Wnon-virtual-dtor` in `osrf_testing_tools_cpp`.