### PR TITLE
[foxy] fix execinfo.h not found for QNX (#50)

### DIFF
--- a/osrf_testing_tools_cpp/src/memory_tools/count_function_occurrences_in_backtrace.hpp
+++ b/osrf_testing_tools_cpp/src/memory_tools/count_function_occurrences_in_backtrace.hpp
@@ -17,7 +17,7 @@
 
 #include "./safe_fwrite.hpp"
 
-#if defined(_WIN32)
+#if defined(_WIN32) || defined(__QNXNTO__)
 
 // Include nothing for now.
 
@@ -50,7 +50,7 @@ struct is_function_pointer
   >
 {};
 
-#if defined(_WIN32)
+#if defined(_WIN32) || defined(__QNXNTO__)
 
 struct count_function_occurrences_in_backtrace_is_implemented : std::false_type {};
 


### PR DESCRIPTION
Backport #50 to Foxy.