### PR TITLE
remove explicit use of -Werror

### DIFF
--- a/test_osrf_testing_tools_cpp/CMakeLists.txt
+++ b/test_osrf_testing_tools_cpp/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+  add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 include(CTest)


### PR DESCRIPTION
This should be enabled/disabled by the user, not the package. Users can use `export CXXFLAGS=-Werror` or pass `--cmake-args -DCMAKE_CXX_FLAGS=-Werror` instead.