### PR TITLE
Use CMAKE_DL_LIBS CMake library to link library that provides dlopen

### DIFF
--- a/osrf_testing_tools_cpp/src/memory_tools/CMakeLists.txt
+++ b/osrf_testing_tools_cpp/src/memory_tools/CMakeLists.txt
@@ -28,14 +28,8 @@ target_include_directories(memory_tools
 )
 target_link_libraries(memory_tools PRIVATE Backward::Backward)
 
-find_library(DL_LIBRARY NAMES dl)
-
-if(UNIX AND NOT APPLE)
-  # On Linux like systems, add dl and use the normal library and LD_PRELOAD.
-
-  if(DL_LIBRARY)
-    target_link_libraries(memory_tools PUBLIC ${DL_LIBRARY})
-  endif()
+if(CMAKE_DL_LIBS)
+  target_link_libraries(memory_tools PUBLIC ${CMAKE_DL_LIBS})
 endif()
 
 target_compile_definitions(memory_tools


### PR DESCRIPTION
CMake provides the [`CMAKE_DL_LIBS`](https://cmake.org/cmake/help/latest/variable/CMAKE_DL_LIBS.html) variable that contain the library that contains `dlopen` and `dlclose`.

Using it, it is possible to avoid to hardcode any platform specific logic, for existing platform and for future platforms, that will just need to set the `CMAKE_DL_LIBS` in their CMake platform file.