### PR TITLE
Add cstring include.

### DIFF
--- a/osrf_testing_tools_cpp/src/memory_tools/is_working.cpp
+++ b/osrf_testing_tools_cpp/src/memory_tools/is_working.cpp
@@ -14,6 +14,7 @@
 
 #include "osrf_testing_tools_cpp/memory_tools/is_working.hpp"
 
+#include <cstring>
 #include <string>
 
 #include "osrf_testing_tools_cpp/memory_tools/register_hooks.hpp"


### PR DESCRIPTION
Needed because of the use of memcpy.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix #69 