### PR TITLE
Fixes policy CMP0135 warning in CMake 3.24

### DIFF
--- a/osrf_testing_tools_cpp/vendor/google/googletest/googletest-external-project-add.cmake.in
+++ b/osrf_testing_tools_cpp/vendor/google/googletest/googletest-external-project-add.cmake.in
@@ -7,6 +7,7 @@ project(googletest-download NONE)
 
 include(ExternalProject)
 ExternalProject_Add(googletest
+  DOWNLOAD_EXTRACT_TIMESTAMP FALSE
   URL               "@GOOGLETEST_ARCHIVE_LOCATION@"
   URL_MD5           "@GOOGLETEST_MD5SUM@"
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-@GOOGLETEST_VERSION@-src"

--- a/osrf_testing_tools_cpp/vendor/google/googletest/googletest-external-project-add.cmake.in
+++ b/osrf_testing_tools_cpp/vendor/google/googletest/googletest-external-project-add.cmake.in
@@ -5,9 +5,13 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(googletest-download NONE)
 
+# Avoid DOWNLOAD_EXTRACT_TIMESTAMP for CMake 3.24
+if (POLICY CMP0135)
+    cmake_policy(SET CMP0135 OLD)
+endif()
+
 include(ExternalProject)
 ExternalProject_Add(googletest
-  DOWNLOAD_EXTRACT_TIMESTAMP FALSE
   URL               "@GOOGLETEST_ARCHIVE_LOCATION@"
   URL_MD5           "@GOOGLETEST_MD5SUM@"
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-@GOOGLETEST_VERSION@-src"

--- a/osrf_testing_tools_cpp/vendor/google/googletest/googletest-external-project-add.cmake.in
+++ b/osrf_testing_tools_cpp/vendor/google/googletest/googletest-external-project-add.cmake.in
@@ -5,9 +5,9 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(googletest-download NONE)
 
-# Avoid DOWNLOAD_EXTRACT_TIMESTAMP for CMake 3.24
+# Avoid DOWNLOAD_EXTRACT_TIMESTAMP warning for CMake >= 3.24
 if (POLICY CMP0135)
-    cmake_policy(SET CMP0135 OLD)
+  cmake_policy(SET CMP0135 OLD)
 endif()
 
 include(ExternalProject)


### PR DESCRIPTION
### Warning fix

Signed-off-by: Cristóbal Arroyo <cristobal.arroyo@ekumenlabs.com>

[This](https://cmake.org/cmake/help/latest/policy/CMP0135.html) warning started appearing on new machines ([windows-container-bd99e2f0](https://ci.ros2.org/computer/windows-container-bd99e2f0/) and [windows-container-9e2bca8d](https://ci.ros2.org/computer/windows-container-9e2bca8d/)). It’s caused by a new CMake version (3.24) that expects this policy to be set.

`osrf_testing_tools_cpp` it's the first package that shows this warning on [Windows Release](https://ci.ros2.org/view/nightly/job/nightly_win_rel/2419/) and [Windows Debug](https://ci.ros2.org/view/nightly/job/nightly_win_deb/2473/)

This PR sets CMP0135 policy by giving the option `DOWNLOAD_EXTRACT_TIMESTAMP FALSE` to `ExternalProject_Add` instruction

Replicating this problem: [![Build Status](https://ci.ros2.org/job/ci_windows/17703/badge/icon)](https://ci.ros2.org/job/ci_windows/17703/)

Solution with this PR changes:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=17243)](http://ci.ros2.org/job/ci_linux/17243/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=11784)](http://ci.ros2.org/job/ci_linux-aarch64/11784/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=17704)](http://ci.ros2.org/job/ci_windows/17704/)
