### PR TITLE
Fixes policy CMP0135 warning for CMake >= 3.24

### DIFF
--- a/test_osrf_testing_tools_cpp/CMakeLists.txt
+++ b/test_osrf_testing_tools_cpp/CMakeLists.txt
@@ -7,6 +7,11 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 11)
 endif()
 
+# Avoid DOWNLOAD_EXTRACT_TIMESTAMP warning for CMake >= 3.24
+if (POLICY CMP0135)
+  cmake_policy(SET CMP0135 OLD)
+endif()
+
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()


### PR DESCRIPTION
Signed-off-by: Crola1702 <cristobal.arroyo@ekumenlabs.com>

(I've already committed to this repo. But I missed that `test_osrf_testing_tools_cpp` is showing this warning too)

Reference build: https://ci.ros2.org/view/nightly/job/nightly_win_deb/2473/

[This](https://cmake.org/cmake/help/latest/policy/CMP0135.html) warning started appearing on new windows machines. It’s caused by a new CMake version (3.24) that expects this policy to be set.

This PR sets CMP0135 policy in CMakeLists.txt
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=17259)](http://ci.ros2.org/job/ci_linux/17259/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=11798)](http://ci.ros2.org/job/ci_linux-aarch64/11798/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=17739)](http://ci.ros2.org/job/ci_windows/17739/)