### PR TITLE
Sets CMP0135 policy behavior to NEW

### DIFF
--- a/osrf_testing_tools_cpp/vendor/google/googletest/googletest-external-project-add.cmake.in
+++ b/osrf_testing_tools_cpp/vendor/google/googletest/googletest-external-project-add.cmake.in
@@ -7,7 +7,7 @@ project(googletest-download NONE)
 
 # Avoid DOWNLOAD_EXTRACT_TIMESTAMP warning for CMake >= 3.24
 if (POLICY CMP0135)
-  cmake_policy(SET CMP0135 OLD)
+  cmake_policy(SET CMP0135 NEW)
 endif()
 
 include(ExternalProject)


### PR DESCRIPTION
Signed-off-by: Crola1702 <cristobal.arroyo@ekumenlabs.com>

[This comment](https://github.com/ros2/rosbag2/pull/1084#pullrequestreview-1103004078) suggest changing the behavior from OLD to NEW. This PR does that for this package. 

Ci_launch_test:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=17266)](http://ci.ros2.org/job/ci_linux/17266/)
* Linux-aarch64 [![Build Status](https://ci.ros2.org/job/ci_linux-aarch64/11806/badge/icon)](https://ci.ros2.org/job/ci_linux-aarch64/11806/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=17746)](http://ci.ros2.org/job/ci_windows/17746/)