### PR TITLE
add get_backtrace method

### DIFF
--- a/osrf_testing_tools_cpp/include/osrf_testing_tools_cpp/memory_tools/memory_tools_service.hpp
+++ b/osrf_testing_tools_cpp/include/osrf_testing_tools_cpp/memory_tools/memory_tools_service.hpp
@@ -93,6 +93,11 @@ struct MemoryToolsService
   void
   print_backtrace();
 
+  /// Returns a backtrace stream for logging.
+  OSRF_TESTING_TOOLS_CPP_MEMORY_TOOLS_PUBLIC
+  std::ostringstream
+  get_backtrace();
+
   /// Returns a stack trace object for introspection.
   /**
    * Pointer should not be used after MemoryToolsService is out of scope.

--- a/osrf_testing_tools_cpp/src/memory_tools/memory_tools_service.cpp
+++ b/osrf_testing_tools_cpp/src/memory_tools/memory_tools_service.cpp
@@ -93,6 +93,22 @@ MemoryToolsService::print_backtrace()
   impl_->should_print_backtrace = true;
 }
 
+
+std::ostringstream
+MemoryToolsService::get_backtrace()
+{
+  std::ostringstream oss;
+#if !defined(_WIN32) && !defined(__ANDROID__)
+  backward::StackTrace st;
+  st.load_here(256);
+  backward::Printer p;
+  p.print(st, oss);
+#else
+  oss << "backtrace unavailable on Windows and Android\n";
+#endif  // !defined(_WIN32) && !defined(__ANDROID__)
+  return oss;
+}
+
 StackTrace *
 MemoryToolsService::get_stack_trace()
 {


### PR DESCRIPTION
Thank you for this great testing tools.
memory_tools is quite good to investigate dynamic memory allocation in RT thread.

In this PR, I add get_backtrace method to get  backtrace in `std::osstringstream` format.
This method is useful when you want to use the stream with ROS logger like. (I'm using ROS1 now)

```c++
ROS_ERROR_STREAM("Backtrace:\n" << service.get_backtrace().str());
```