### PR TITLE
add method to access MemoryToolsService members

### DIFF
--- a/osrf_testing_tools_cpp/include/osrf_testing_tools_cpp/memory_tools/memory_tools_service.hpp
+++ b/osrf_testing_tools_cpp/include/osrf_testing_tools_cpp/memory_tools/memory_tools_service.hpp
@@ -87,11 +87,21 @@ struct MemoryToolsService
   void
   unignore();
 
+  // Return ignored or not.
+  OSRF_TESTING_TOOLS_CPP_MEMORY_TOOLS_PUBLIC
+  bool
+  get_ignored();
+
   /// Adds a backtrace to the log message.
   /** Repeated calls do nothing, and only prints if a log is also printed. */
   OSRF_TESTING_TOOLS_CPP_MEMORY_TOOLS_PUBLIC
   void
   print_backtrace();
+
+  // Return print back trace or not.
+  OSRF_TESTING_TOOLS_CPP_MEMORY_TOOLS_PUBLIC
+  bool
+  get_print_backtrace();
 
   /// Returns a stack trace object for introspection.
   /**

--- a/osrf_testing_tools_cpp/src/memory_tools/memory_tools_service.cpp
+++ b/osrf_testing_tools_cpp/src/memory_tools/memory_tools_service.cpp
@@ -87,10 +87,22 @@ MemoryToolsService::unignore()
   impl_->ignored = false;
 }
 
+bool
+MemoryToolsService::get_ignored()
+{
+  return impl_->ignored;
+}
+
 void
 MemoryToolsService::print_backtrace()
 {
   impl_->should_print_backtrace = true;
+}
+
+bool
+MemoryToolsService::get_print_backtrace()
+{
+  return impl_->should_print_backtrace;
 }
 
 StackTrace *


### PR DESCRIPTION
this PR adds access method to MemoryToolsService members `ignored` and `print_traceback`.
this PR is used for debugging in #80 