### PR TITLE
[Backport]Fix mpark/variant conditional for MSVC (#77)

### DIFF
--- a/osrf_testing_tools_cpp/include/osrf_testing_tools_cpp/variant_helper.hpp
+++ b/osrf_testing_tools_cpp/include/osrf_testing_tools_cpp/variant_helper.hpp
@@ -18,7 +18,7 @@
 #if defined(__has_include)
 
 # if __has_include(<variant>)
-#  if _MSC_VER < 2000  // this is any version @ VS 2017 and earlier
+#  if defined(_MSC_VER) && _MSC_VER < 2000  // this is any version @ VS 2017 and earlier
 // VS 2017 (_MSC_VER or 19XX) has <variant>, but it just contains an error macro...
 #   define __SHOULD_USE_MPARK_VARIANT 1
 #  else  // _MSC_VER < 2000


### PR DESCRIPTION
This conditional currently evaluates to TRUE when _MSC_VER is not defined, meaning that __SHOULD_USE_MPARK_VARIANT is 1 for ALL SYSTEMS except newer MSVC, which is certainly not correct.

Fixes 06e1dbe4ffb1d677a237f00035e323896dc7ffdb